### PR TITLE
feat: add Read the Docs configuration file for documentation build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,33 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  jobs:
+    post_create_environment:
+      # Install uv
+      - pip install uv
+    post_install:
+      # Install dependencies with 'docs' dependency group
+      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv sync --group docs
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt
+        


### PR DESCRIPTION
This pull request adds a Read the Docs configuration file to the project, enabling automated documentation builds using Sphinx with a modern Python environment and dependency management.

Documentation build setup:

* Added a new `.readthedocs.yml` configuration file to specify build settings, including Ubuntu 24.04 as the OS, Python 3.12, and the use of the `uv` tool for dependency installation.
* Configured the build to install documentation dependencies using the Poetry `docs` dependency group and to build docs from the `docs/` directory with Sphinx.