### PR TITLE
fix: update Sphinx configuration path in Read the Docs setup

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,7 +22,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+   configuration: docs/source/conf.py
 
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation


### PR DESCRIPTION
This pull request updates the Sphinx documentation build configuration path in the `.readthedocs.yml` file to reflect the correct location of the configuration file.

Documentation configuration update:

* Changed the Sphinx `configuration` path from `docs/conf.py` to `docs/source/conf.py` in `.readthedocs.yml`, ensuring Read the Docs uses the correct configuration file for building documentation.