### PR TITLE
fix: remove unnecessary extra_footer from Sphinx theme options

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,7 +121,6 @@ html_theme_options = {
       "image_light": "_static/img/logo-maverick-light.svg",
       "image_dark": "_static/img/logo-maverick-dark.svg",
     },
-    "extra_footer": "<div>hi there!</div>"
 }
 
 # Intersphinx configuration


### PR DESCRIPTION
This pull request makes a minor update to the documentation configuration. The change removes a custom footer from the documentation site.