### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file. If you are 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.1] - 2026.01.25
+
+### Fixed
+
+- Handled edge case in game flow logic, where all players go either all-in or fold pre-flop.
+
+## [0.2.0] - 2026.01.25
 
 ### Deprecated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maverick"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Python library for simulating poker games with custom player strategies"
 readme = "README.md"
 authors = [

--- a/src/maverick/game.py
+++ b/src/maverick/game.py
@@ -504,8 +504,19 @@ class Game:
                 | GameEventType.RIVER_DEALT
             ):
                 self._emit(self._create_event(GameEventType.BETTING_ROUND_STARTED))
-                self._take_action_from_current_player()
-                self._event_queue.append(GameEventType.PLAYER_ACTION_TAKEN)
+                if self.state.is_betting_round_complete():
+                    self._complete_betting_round()
+                    self._emit(
+                        self._create_event(GameEventType.BETTING_ROUND_COMPLETED)
+                    )
+                    self._event_queue.append(GameEventType.BETTING_ROUND_COMPLETED)
+                    self._log(
+                        "There are not active players at the table.",
+                        logging.INFO,
+                    )
+                else:
+                    self._take_action_from_current_player()
+                    self._event_queue.append(GameEventType.PLAYER_ACTION_TAKEN)
 
             case GameEventType.SHOWDOWN_COMPLETED:
                 self.state.stage = GameStage.HAND_COMPLETE
@@ -732,6 +743,8 @@ class Game:
             # - BB = left of SB
             sb_index = self.table.next_occupied_seat(self.state.button_position)
             bb_index = self.table.next_occupied_seat(sb_index)
+        assert isinstance(sb_index, int)
+        assert isinstance(bb_index, int)
 
         # --- Small blind ---
         sb_player = self.table[sb_index]
@@ -780,8 +793,10 @@ class Game:
             self.state.current_player_index = sb_index
         else:
             self.state.current_player_index = self.table.next_occupied_seat(bb_index)
-        
-        assert isinstance(self.state.current_player_index, int), "Current player index must be an integer"
+
+        assert isinstance(
+            self.state.current_player_index, int
+        ), "Current player index must be an integer"
 
     def _post_antes(self) -> None:
         """Post antes for all active players."""

--- a/src/maverick/state.py
+++ b/src/maverick/state.py
@@ -33,9 +33,7 @@ class GameState(BaseModel):
         The current betting round (e.g., PRE_FLOP, FLOP, TURN, RIVER).
     players : list[PlayerLike]
         The list of players in the game.
-    active_players : list[int]
-        Indices of players who are still active in the current hand.
-    current_player_index : int
+    current_player_index : Optional[int]
         The index of the player whose turn it is to act.
     deck : Optional[Deck]
         The deck of cards used in the game.
@@ -64,8 +62,7 @@ class GameState(BaseModel):
     stage: GameStage = GameStage.WAITING_FOR_PLAYERS
     street: Optional[Street] = None
     players: list[PlayerLike] = Field(default_factory=list)
-    active_players: list[int] = Field(default_factory=list)  # Indices of active players
-    current_player_index: int = 0
+    current_player_index: Optional[int] = None
 
     # Cards
     deck: Optional[Deck] = None

--- a/src/maverick/table.py
+++ b/src/maverick/table.py
@@ -136,7 +136,8 @@ class Table:
         for offset in range(1, self._n_seats + 1):
             next_seat = (start_seat + offset) % self._n_seats
             next_player = self.seats[next_seat]
-            if not next_player:
+
+            if next_player is None:
                 continue
 
             if not active or (next_player.state.state_type == PlayerStateType.ACTIVE):

--- a/tests/test_archetypes.py
+++ b/tests/test_archetypes.py
@@ -1,7 +1,6 @@
 import unittest
 
-from maverick import Game
-from maverick.playerstate import PlayerState
+from maverick import Game, PlayerState
 from maverick.players import (
     TightAggressiveBot,
     LooseAggressiveBot,

--- a/tests/test_game_flow_edge_cases.py
+++ b/tests/test_game_flow_edge_cases.py
@@ -1,0 +1,164 @@
+"""Tests for the Deck class."""
+
+import unittest
+from collections import Counter
+
+from maverick.players import FoldBot, CallBot, AggressiveBot
+from maverick import (
+    Game,
+    PlayerState,
+    PlayerStateType,
+    GameState,
+    GameStage,
+    Street,
+    Deck,
+    GameEventType,
+)
+
+
+class TestGameFlowEdgeCases(unittest.TestCase):
+    """Test edge cases related to the game flow."""
+
+    def test_no_active_players_after_preflop(self):
+        """Tests the scenario where all players go all-in pre-flop."""
+        game = Game(small_blind=10, big_blind=20, max_hands=1)
+
+        p1 = CallBot(name="CallBot", state=PlayerState(stack=1000))
+        p2 = AggressiveBot(name="AggroBot", state=PlayerState(stack=1000))
+        p3 = FoldBot(name="FoldBot", state=PlayerState(stack=1000))
+        players = [p1, p2, p3]
+
+        for player in players:
+            game.add_player(player)
+
+        p1.state = PlayerState(
+            seat=0,
+            stack=0,
+            state_type=PlayerStateType.ALL_IN,
+            current_bet=1000,
+            total_contributed=1000,
+            acted_this_street=True,
+        )
+
+        p2.state = PlayerState(
+            seat=1,
+            stack=0,
+            state_type=PlayerStateType.ALL_IN,
+            current_bet=1000,
+            total_contributed=1000,
+            acted_this_street=True,
+        )
+
+        p3.state = PlayerState(
+            seat=2,
+            stack=0,
+            state_type=PlayerStateType.ALL_IN,
+            current_bet=1000,
+            total_contributed=1000,
+            acted_this_street=True,
+        )
+
+        game._state = GameState(
+            stage=GameStage.PRE_FLOP,
+            street=Street.PRE_FLOP,
+            players=players,
+            current_player_index=2,
+            deck=Deck.standard_deck(),
+            community_cards=[],
+            pot=3000,
+            current_bet=1000,
+            min_bet=1000,
+            last_raise_size=1000,
+            small_blind=10,
+            big_blind=20,
+            ante=0,
+            hand_number=1,
+            button_position=0,
+        )
+
+        game._event_queue.append(GameEventType.BETTING_ROUND_COMPLETED)
+        self.assertTrue(game.has_events())
+        self.assertEqual(game._event_queue[0], GameEventType.BETTING_ROUND_COMPLETED)
+
+        _ = game.step()
+        self.assertTrue(game.has_events())
+        self.assertEqual(game._event_queue[0], GameEventType.FLOP_DEALT)
+
+        _ = game.step()
+        self.assertTrue(game.has_events())
+        self.assertEqual(game._event_queue[0], GameEventType.BETTING_ROUND_COMPLETED)
+
+    def test_players_eliminated_during_hand(self):
+        """Tests the scenario where players are eliminated during a hand."""
+        game = Game(small_blind=10, big_blind=20, max_hands=1)
+
+        p1 = CallBot(name="CallBot", state=PlayerState(stack=1000))
+        p2 = AggressiveBot(name="AggroBot", state=PlayerState(stack=1000))
+        p3 = FoldBot(name="FoldBot", state=PlayerState(stack=1000))
+        players = [p1, p2, p3]
+
+        for player in players:
+            game.add_player(player)
+
+        p1.state = PlayerState(
+            seat=0,
+            stack=0,
+            state_type=PlayerStateType.ALL_IN,
+            current_bet=1000,
+            total_contributed=1000,
+            acted_this_street=True,
+        )
+
+        p2.state = PlayerState(
+            seat=1,
+            stack=3000,
+            state_type=PlayerStateType.ALL_IN,
+            current_bet=1000,
+            total_contributed=1000,
+            acted_this_street=True,
+        )
+
+        p3.state = PlayerState(
+            seat=2,
+            stack=0,
+            state_type=PlayerStateType.ALL_IN,
+            current_bet=1000,
+            total_contributed=1000,
+            acted_this_street=True,
+        )
+
+        game._state = GameState(
+            stage=GameStage.SHOWDOWN,
+            street=None,
+            players=players,
+            current_player_index=2,
+            deck=Deck.standard_deck(),
+            community_cards=[],
+            pot=0,
+            current_bet=0,
+            min_bet=0,
+            last_raise_size=0,
+            small_blind=10,
+            big_blind=20,
+            ante=0,
+            hand_number=1,
+            button_position=0,
+        )
+
+        game._event_queue.append(GameEventType.SHOWDOWN_COMPLETED)
+        self.assertTrue(game.has_events())
+        self.assertEqual(game._event_queue[0], GameEventType.SHOWDOWN_COMPLETED)
+
+        _ = game.step()
+        self.assertTrue(game.has_events())
+        self.assertEqual(game._event_queue[0], GameEventType.HAND_ENDED)
+
+        _ = game.step()
+        c = Counter(game._event_queue)
+        self.assertEqual(c[GameEventType.PLAYER_ELIMINATED], 2)
+        self.assertEqual(c[GameEventType.PLAYER_LEFT], 2)
+        self.assertEqual(c[GameEventType.GAME_ENDED], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -974,7 +974,7 @@ wheels = [
 
 [[package]]
 name = "maverick"
-version = "0.1.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This pull request addresses an edge case in the poker game flow logic where all players go all-in or fold pre-flop, ensuring the game progresses correctly in these scenarios. It also introduces new tests to cover these edge cases and makes several improvements and fixes to the codebase for robustness and clarity.

**Game flow and bug fixes:**

* Fixed a bug in the game flow logic by handling the case where all players are all-in or have folded pre-flop, ensuring the betting round completes and the game advances as expected (`src/maverick/game.py`).
* Updated assertions and type handling for seat indices and the current player index to prevent type errors and clarify intent (`src/maverick/game.py`, `src/maverick/state.py`). [[1]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69R746-R747) [[2]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69L784-R799) [[3]](diffhunk://#diff-5b1f8fcffa0bc4869ecb419895070ccd9454a5056a20fa9b2c9d3badf5c92304L36-R36) [[4]](diffhunk://#diff-5b1f8fcffa0bc4869ecb419895070ccd9454a5056a20fa9b2c9d3badf5c92304L67-R65)
* Fixed a bug in `next_occupied_seat` to correctly skip empty seats by checking for `None` explicitly (`src/maverick/table.py`).

**Testing improvements:**

* Added a new test file `test_game_flow_edge_cases.py` with tests for scenarios where all players go all-in pre-flop and for player eliminations during a hand (`tests/test_game_flow_edge_cases.py`).

**Documentation and versioning:**

* Updated the `CHANGELOG.md` to document the bug fix and released version 0.2.1 (`CHANGELOG.md`).
* Bumped the package version from 0.2.0 to 0.2.1 in `pyproject.toml`.

**Miscellaneous:**

* Minor import cleanup in `test_archetypes.py` to simplify imports.