### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file. If you are 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026.02.07
+
+- Added `ELIMINATED` state to `PlayerStateType` enum for better player state tracking.
+
 ## [0.2.1] - 2026.01.25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maverick"
-version = "0.2.2"
+version = "0.2.3"
 description = "A Python library for simulating poker games with custom player strategies"
 readme = "README.md"
 authors = [

--- a/src/maverick/enums.py
+++ b/src/maverick/enums.py
@@ -190,11 +190,14 @@ class PlayerStateType(Enum):
     ALL_IN : str
         Player has bet all their chips and cannot take further actions, but remains
         in the hand competing for pots they contributed to.
+    ELIMINATED : str
+        Player has lost all their chips and is out of the game.
     """
 
     ACTIVE = auto()
     FOLDED = auto()
     ALL_IN = auto()
+    ELIMINATED = auto()
 
 
 class GameStage(Enum):

--- a/src/maverick/game.py
+++ b/src/maverick/game.py
@@ -337,13 +337,16 @@ class Game:
             f"Player {player.name} joined the game.", logging.INFO, stage_prefix=False
         )
 
-    def remove_player(self, player: PlayerLike) -> None:
+    def remove_player(self, player: PlayerLike, flush: bool = True) -> None:
         """Remove a player from the game.
 
         Parameters
         ----------
         player : PlayerLike
             The player to remove from the game.
+        flush : bool
+            If True, immediately process the resulting events. If False, the events will be
+            added to the queue but not processed until step() is called. Default is True.
         """
         player_id = player.id
 
@@ -362,10 +365,14 @@ class Game:
         self.table.remove_player(player)
         self.state.players = [p for p in self.state.players if p.id != player_id]
 
-        self._handle_event(GameEventType.PLAYER_LEFT)
+        if flush:
+            self._handle_event(GameEventType.PLAYER_LEFT)
+        else:
+            self._event_queue.append(GameEventType.PLAYER_LEFT)
+
         self._emit(self._create_event(GameEventType.PLAYER_LEFT, player_id=player_id))
         self._log(
-            f"Player {player.name} left the game.", logging.INFO, stage_prefix=False
+            f"Player {player.name} has left the game.", logging.INFO, stage_prefix=False
         )
 
     def start(self) -> None:
@@ -462,6 +469,7 @@ class Game:
 
             case GameEventType.BETTING_ROUND_COMPLETED:
                 if len(self.state.get_players_in_hand()) == 1:
+                    # There is no or only one active player left, so we skip to showdown
                     self.state.stage = GameStage.SHOWDOWN
                     self.state.street = None
                     self._emit(self._create_event(GameEventType.SHOWDOWN_STARTED))
@@ -469,6 +477,7 @@ class Game:
                     self._emit(self._create_event(GameEventType.SHOWDOWN_COMPLETED))
                     self._event_queue.append(GameEventType.SHOWDOWN_COMPLETED)
                 else:
+                    # There is at least 2 active players, so we continue to next street
                     if self.state.stage == GameStage.PRE_FLOP:
                         self.state.stage = GameStage.FLOP
                         self.state.street = Street.FLOP
@@ -526,11 +535,12 @@ class Game:
             case GameEventType.HAND_ENDED:
                 self._log("Hand ended\n", logging.INFO, stage_prefix=False)
 
-                # eliminate players with zero stack
+                # Eliminate players with zero stack
                 eliminated_players = [
                     p for p in self.state.players if p.state.stack == 0
                 ]
                 for player in eliminated_players:
+                    player.state.state_type = PlayerStateType.ELIMINATED
                     self._emit(
                         self._create_event(
                             GameEventType.PLAYER_ELIMINATED, player_id=player.id
@@ -542,26 +552,9 @@ class Game:
                         stage_prefix=False,
                     )
                     self._event_queue.append(GameEventType.PLAYER_ELIMINATED)
+                    self.remove_player(player, flush=False)
 
-                # Remove eliminated players from the game
-                self.state.players = [
-                    p for p in self.state.players if p.state.stack > 0
-                ]
-
-                # remove eliminated players from the table
-                for player in eliminated_players:
-                    self._emit(
-                        self._create_event(
-                            GameEventType.PLAYER_LEFT, player_id=player.id
-                        )
-                    )
-                    self._log(
-                        f"Player {player.name} has left the table.",
-                        logging.INFO,
-                        stage_prefix=False,
-                    )
-                    self._event_queue.append(GameEventType.PLAYER_LEFT)
-
+                # Check if we have enough players to continue
                 if len(self.state.players) < self.rules.dealing.min_players:
                     self._log(
                         "Not enough players to continue, ending game.", logging.INFO
@@ -569,6 +562,7 @@ class Game:
                     self.state.stage = GameStage.GAME_OVER
                     self._event_queue.append(GameEventType.GAME_ENDED)
                 else:
+                    # Move button and start next hand
                     self._move_button()
 
                     if self.state.hand_number >= self._max_hands:
@@ -736,13 +730,17 @@ class Game:
         # - Other player is BIG blind
         if num_players == 2:
             sb_index = self.state.button_position
-            bb_index = self.table.next_occupied_seat(self.state.button_position)
+            bb_index = self.table.next_occupied_seat(
+                self.state.button_position, active=True
+            )
         else:
             # Multi-way:
             # - SB = left of button
             # - BB = left of SB
-            sb_index = self.table.next_occupied_seat(self.state.button_position)
-            bb_index = self.table.next_occupied_seat(sb_index)
+            sb_index = self.table.next_occupied_seat(
+                self.state.button_position, active=True
+            )
+            bb_index = self.table.next_occupied_seat(sb_index, active=True)
         assert isinstance(sb_index, int)
         assert isinstance(bb_index, int)
 
@@ -792,7 +790,9 @@ class Game:
         if num_players == 2:
             self.state.current_player_index = sb_index
         else:
-            self.state.current_player_index = self.table.next_occupied_seat(bb_index)
+            self.state.current_player_index = self.table.next_occupied_seat(
+                bb_index, active=True
+            )
 
         assert isinstance(
             self.state.current_player_index, int
@@ -1165,7 +1165,7 @@ class Game:
             self.state.pot = 0
         else:
             assert (
-                len(self.state.community_cards) == 5
+                len(self.state.community_cards) == self.rules.dealing.board_cards_total
             ), "Community cards incomplete at multi-player showdown."
 
             all_contributions = sum(

--- a/src/maverick/state.py
+++ b/src/maverick/state.py
@@ -143,22 +143,24 @@ class GameState(BaseModel):
 
     def get_players_in_hand(self) -> list[PlayerLike]:
         """Return list of players still in the hand (not folded)."""
-        return [p for p in self.players if p.state.state_type != PlayerStateType.FOLDED]
+        return [
+            p
+            for p in self.players
+            if p.state.state_type in [PlayerStateType.ACTIVE, PlayerStateType.ALL_IN]
+        ]
 
     def is_betting_round_complete(self) -> bool:
         """Betting round is complete when no further action is possible/required."""
-        in_hand = [
-            p for p in self.players if p.state.state_type != PlayerStateType.FOLDED
-        ]
+        in_hand = self.get_players_in_hand()
 
         # If only one player remains, hand is effectively over
         if len(in_hand) <= 1:
             return True
 
-        can_act = [p for p in in_hand if p.state.state_type == PlayerStateType.ACTIVE]
+        can_act = self.get_active_players()
 
-        # If nobody can act (everyone left is all-in), betting is complete
-        if not can_act:
+        # If less than 2 players can act, betting is complete
+        if len(can_act) < 2:
             return True
 
         # Everyone who can act must have acted since the last reopen

--- a/uv.lock
+++ b/uv.lock
@@ -974,7 +974,7 @@ wheels = [
 
 [[package]]
 name = "maverick"
-version = "0.2.1"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This pull request introduces enhancements to player state tracking and improves the handling of player elimination and game progression logic in the poker simulation library. The main changes include adding an `ELIMINATED` state to the `PlayerStateType` enum, refactoring player removal and elimination flows, and updating logic to ensure only active players are considered during game actions.

**Player state tracking improvements:**

* Added `ELIMINATED` state to the `PlayerStateType` enum for clearer distinction when a player is out of the game. [[1]](diffhunk://#diff-3827d7a9a938ae8d259450b21731ec6b1dd5710fc634300cd6c2b54f181adcbaR193-R200) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R11)

**Player elimination and removal logic:**

* Refactored the player removal flow in `Game` to use the new `ELIMINATED` state and to process removal events more efficiently, including updating the `remove_player` method to support event queue flushing. [[1]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69L340-R349) [[2]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69R368-R375) [[3]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69L529-R543) [[4]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69R555-R565)
* Eliminated players are now removed from the game and table only after their state is set to `ELIMINATED`, and related events are queued and emitted accordingly. [[1]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69L529-R543) [[2]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69R555-R565)

**Game logic and active player handling:**

* Updated methods such as `get_players_in_hand` and `is_betting_round_complete` in `State` to only include players with `ACTIVE` or `ALL_IN` states, ensuring that eliminated and folded players are excluded from game actions.
* Improved logic for posting blinds and determining the current player to only consider active players, preventing issues with eliminated or folded players. [[1]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69L739-R743) [[2]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69L795-R795)

**General improvements and bug fixes:**

* Updated showdown logic to use the correct number of community cards based on game rules, improving robustness in multi-player scenarios.
* Bumped version to `0.2.3` and updated the changelog to reflect these enhancements. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R11)