### PR TITLE
Add read-only game_id property and UUID generation to Game class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file. If you are 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `game_id` read-only property to the `Game` class. A new unique identifier (32-character UUID4 hex string) is generated each time a game starts, tied to the `GAME_STARTED` event.
+
 ## [0.4.0] - 2026.02.22
 
 ### Added

--- a/docs/source/user_guide/games.ipynb
+++ b/docs/source/user_guide/games.ipynb
@@ -168,6 +168,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1nqjgm2yhfy",
+   "source": "## Game ID\n\nEvery game has a unique identifier accessible via the `game_id` read-only property. A new ID is generated each time the `GAME_STARTED` event fires, so the same `Game` instance can be reused across multiple sessions while still producing a distinct identifier for each one.\n\nBefore the game starts, `game_id` is `None`:",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "w4suwfw186",
+   "source": "from maverick import Game, PlayerState\nfrom maverick.players import FoldBot, CallBot\n\ngame = Game(small_blind=10, big_blind=20, max_hands=1)\nprint(f\"Before start: game.game_id = {game.game_id}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s8t6l0sw62q",
+   "source": "After calling `start()`, the `game_id` is a 32-character hex string (UUID4):",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7pydfrq538a",
+   "source": "game.add_player(FoldBot(name=\"Alice\", state=PlayerState(stack=1000)))\ngame.add_player(CallBot(name=\"Bob\", state=PlayerState(stack=1000)))\ngame.start()\nprint(f\"After start: game.game_id = {game.game_id}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "6c5cfb4d",
    "metadata": {},
    "source": [

--- a/src/maverick/game.py
+++ b/src/maverick/game.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Deque, Optional
 from collections import deque
 import logging
+import uuid
 from warnings import warn
 
 from .deck import Deck
@@ -137,9 +138,28 @@ class Game:
         # Event handling
         self._events = EventBus(strict=exc_handling_mode == "raise")
         self._event_history: list[GameEvent] = []
+        self._game_uid: Optional[str] = None
 
         # Table
         self._table = Table(n_seats=rules.dealing.max_players)
+
+    @property
+    def game_id(self) -> Optional[str]:
+        """Returns the unique identifier for the current game, or None if the game has not started yet.
+
+        A new ``game_id`` is generated each time a game starts (i.e. when the ``GAME_STARTED`` event
+        is fired). This allows the same :class:`Game` instance to be reused across multiple games
+        while still providing a unique identifier for each one.
+
+        Returns
+        -------
+        Optional[str]
+            A 32-character hex string (UUID4) identifying the current game, or ``None`` before the
+            game has started.
+
+        .. versionadded:: 0.5.0
+        """
+        return self._game_uid
 
     @property
     def rules(self) -> PokerRules:
@@ -450,6 +470,7 @@ class Game:
         match event:
             case GameEventType.GAME_STARTED:
                 assert self.state.stage == GameStage.READY
+                self._game_uid = uuid.uuid4().hex
                 self.state.stage = GameStage.STARTED
                 self._emit(self._create_event(GameEventType.GAME_STARTED))
                 self._start_new_hand()

--- a/tests/test_game_uid.py
+++ b/tests/test_game_uid.py
@@ -1,0 +1,85 @@
+"""Tests for the game_id (unique game identifier) feature."""
+
+import unittest
+
+from maverick import Game, Player, PlayerState, PlayerAction, ActionType, GameEventType
+from maverick.enums import GameStage
+from maverick.players import FoldBot, CallBot
+
+
+DEFAULT_SMALL_BLIND = 10
+DEFAULT_BIG_BLIND = 20
+
+
+def make_game(**kwargs) -> Game:
+    base = {"small_blind": DEFAULT_SMALL_BLIND, "big_blind": DEFAULT_BIG_BLIND, "max_hands": 1}
+    base.update(kwargs)
+    return Game(**base)
+
+
+def add_players(game: Game, n: int = 2) -> None:
+    bots = [FoldBot, CallBot]
+    for i in range(n):
+        cls = bots[i % len(bots)]
+        game.add_player(cls(name=f"Player{i}", state=PlayerState(stack=1000)))
+
+
+class TestGameId(unittest.TestCase):
+    """Tests for the game_id property."""
+
+    def test_game_id_is_none_before_start(self):
+        """game_id should be None before the game starts."""
+        game = make_game()
+        self.assertIsNone(game.game_id)
+
+    def test_game_id_is_string_after_start(self):
+        """game_id should be a string after the game starts."""
+        game = make_game()
+        add_players(game)
+        game.start()
+        self.assertIsInstance(game.game_id, str)
+
+    def test_game_id_is_32_chars(self):
+        """game_id should be a 32-character hex string (UUID4 hex)."""
+        game = make_game()
+        add_players(game)
+        game.start()
+        self.assertEqual(len(game.game_id), 32)
+
+    def test_game_id_is_read_only(self):
+        """game_id property should be read-only."""
+        game = make_game()
+        add_players(game)
+        game.start()
+        with self.assertRaises(AttributeError):
+            game.game_id = "some-value"
+
+    def test_game_id_unique_across_instances(self):
+        """Two separate Game instances should have different game_ids."""
+        game1 = make_game()
+        game2 = make_game()
+        add_players(game1)
+        add_players(game2)
+        game1.start()
+        game2.start()
+        self.assertNotEqual(game1.game_id, game2.game_id)
+
+    def test_game_id_generated_on_game_started_event(self):
+        """game_id should be set when the GAME_STARTED event is processed."""
+        game = make_game(max_hands=5)
+        add_players(game)
+        game._initialize_game()
+        game._event_queue.append(GameEventType.GAME_STARTED)
+
+        # Before draining the GAME_STARTED event
+        self.assertIsNone(game.game_id)
+
+        game.step()  # process GAME_STARTED
+
+        # After GAME_STARTED event is processed, game_id should be set
+        self.assertIsNotNone(game.game_id)
+        self.assertEqual(len(game.game_id), 32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new unique identifier feature for each game session in the `Game` class. The `game_id` property is now available, providing a 32-character UUID4 hex string that is generated every time a game starts (i.e., when the `GAME_STARTED` event fires). This allows for better tracking and differentiation of game sessions, even when reusing the same `Game` instance. The documentation and tests have been updated to reflect and verify this new functionality.

**Game unique identifier feature:**

* Added a read-only `game_id` property to the `Game` class, which returns a 32-character UUID4 hex string generated on each `GAME_STARTED` event, or `None` before the game starts. (`src/maverick/game.py`, [[1]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69R141-R163) [[2]](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69R473)
* Updated the changelog to document the addition of the `game_id` property and its behavior. (`CHANGELOG.md`, [CHANGELOG.mdR8-R13](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13))
* Expanded the user guide with a new section explaining the `game_id` property, including code examples showing its usage before and after starting a game. (`docs/source/user_guide/games.ipynb`, [docs/source/user_guide/games.ipynbR169-R196](diffhunk://#diff-4fe5c49d39d2ef1a101197156c28e9851ac4eac9665c9a6409eb4b8748628505R169-R196))

**Testing:**

* Added comprehensive unit tests for the `game_id` property, covering its value before and after game start, uniqueness across instances, read-only behavior, and correct generation on the `GAME_STARTED` event. (`tests/test_game_uid.py`, [tests/test_game_uid.pyR1-R85](diffhunk://#diff-2206f408a6a4f6c18c8d409d59eae73e84df3d7bce48a41304cad38d4e2abf25R1-R85))

**Dependency:**

* Imported the `uuid` module to support UUID4 generation for the game ID. (`src/maverick/game.py`, [src/maverick/game.pyR14](diffhunk://#diff-41522cf883251738682af9c1315937a6cdef5ea35b9b8f8e9be5fcd85b4eec69R14))